### PR TITLE
feat: ✨ add support for filtering suggestions by multiple country codes

### DIFF
--- a/lib/src/infrastructure/google_api_facade.dart
+++ b/lib/src/infrastructure/google_api_facade.dart
@@ -22,16 +22,29 @@ class GoogleApiFacade implements IGoogleApiFacade {
     required String apikey,
     required String value,
     required String? webCorsUrl,
+    List<String>? countriesCodes,
   }) async {
     try {
       final headers = await const GoogleApiHeaders().getHeaders();
       final url = kIsWeb && webCorsUrl != null
           ? '$webCorsUrl/${ApiConstants.baseUrl}${ApiConstants.autocomplete}'
           : ApiConstants.autocomplete;
+      String? components;
+
+      if (countriesCodes != null && countriesCodes.isNotEmpty) {
+        components = countriesCodes
+            .map((code) => 'country:${code.toUpperCase()}')
+            .join('|');
+      }
 
       final response = await apiService.dioClient.get(
         url,
-        queryParameters: {"input": value, "key": apikey},
+        queryParameters: {
+          "input": value,
+          "key": apikey,
+          if (components != null && components.isNotEmpty)
+            "components": components,
+        },
         options: Options(headers: headers),
       );
 

--- a/lib/src/presentation/place_search_field.dart
+++ b/lib/src/presentation/place_search_field.dart
@@ -41,6 +41,7 @@ class PlaceSearchField extends StatefulWidget {
     this.hideOnError = false,
     this.hideOnLoading = false,
     this.animationDuration,
+    this.countriesCodes,
   }) : assert(apiKey.isNotEmpty, 'API key cannot be empty');
 
   /// The Google API key used for querying the Places API.
@@ -145,6 +146,9 @@ class PlaceSearchField extends StatefulWidget {
   /// Offset for positioning the dropdown relative to the text field.
   final Offset? offset;
 
+  /// Optional country codes to restrict the search results to specific countries.
+  final List<String>? countriesCodes;
+
   @override
   State<PlaceSearchField> createState() => _PlaceSearchFieldState();
 }
@@ -159,6 +163,7 @@ class _PlaceSearchFieldState extends State<PlaceSearchField> {
       apikey: widget.apiKey,
       value: input,
       webCorsUrl: widget.webCorsProxyUrl,
+      countriesCodes: widget.countriesCodes,
     );
 
     return result.fold(


### PR DESCRIPTION
# 📝 Pull Request

### 📢 Description
This PR introduces support for filtering Google Places autocomplete suggestions by multiple country codes. The PlaceSearchField widget and GoogleApiFacade have been enhanced to accept a list of countries, providing more relevant suggestions for apps targeting multiple regions.

### Changes Made
🆕 Added a new parameter countriesCodes (List<String>) to PlaceSearchField.
🔧 Updated GoogleApiFacade.getLocationInfo to construct the components query parameter for multiple countries, e.g.,     components=country:IQ|country:KW.
♻️ Backward compatible: works with single-country, multiple countries, or no country filter.
📝 Minor improvements in handling API requests and suggestion processing.

### Usage Example
PlaceSearchField(
  apiKey: googlePlacesApiKey,
  countriesCodes: ['IQ', 'KW'], // Limits suggestions to Iraq and Kuwait
  itemBuilder: (context, prediction) => Text(prediction.description),
  onPlaceSelected: (prediction, details) {
    // Handle selection
  },
)

### Benefits
🌍 Provides region-specific suggestions for a better user experience.
🔄 Fully backward-compatible with single-country or global searches.
➕ Easy to extend to more countries without modifying core API logic.